### PR TITLE
export DefaultFlash

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,7 @@ interface MessageOptions {
 interface FlashMessageProps extends Partial<MessageOptions> {
   canRegisterAsDefault?: boolean;
   style?: StyleProp<ViewStyle>;
-  MessageComponent?: React.ReactElement<MessageComponentProps>;
+  MessageComponent?: React.SFC<MessageComponentProps> | React.ReactElement<MessageComponentProps>;
   transitionConfig?(animValue: Animated.Value, position: Position): Transition;
   renderFlashMessageIcon?(
     icon: Icon,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,6 +65,8 @@ interface FlashMessageProps extends Partial<MessageOptions> {
   ): React.ReactElement<{}> | null;
 }
 
+export class DefaultFlash extends React.Component<MessageComponentProps> {}
+
 export function showMessage(options: MessageOptions): void;
 export function hideMessage(): void;
 export function positionStyle(style: StyleProp<ViewStyle>, position: Position): StyleProp<ViewStyle>;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
 
 import FlashMessageManager from "./FlashMessageManager";
 import FlashMessageWrapper, { styleWithInset } from "./FlashMessageWrapper";
-import FlashMessage, { positionStyle, showMessage, hideMessage, FlashMessageTransition } from "./FlashMessage";
+import FlashMessage, { positionStyle, DefaultFlash, showMessage, hideMessage, FlashMessageTransition } from "./FlashMessage";
 
 export {
   FlashMessageManager,
@@ -10,6 +10,7 @@ export {
   styleWithInset,
   positionStyle,
   showMessage,
+  DefaultFlash,
   hideMessage,
   FlashMessageTransition,
 };


### PR DESCRIPTION
Allows for easy overriding/expanding of specific props and still using the default.