### PR TITLE
Add missing style typings for `showMessage` method

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,6 +49,8 @@ interface MessageOptions {
   icon?: Icon;
   message: string;
   position?: Position;
+  textStyle?: StyleProp<TextStyle>;
+  titleStyle?: StyleProp<TextStyle>;
   type?: MessageType;
   onPress?(): void;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -19,11 +19,19 @@ type Transition =
   | { opacity: number }
   | {};
 
-interface MessageComponentProps {
-  position: Position;
-  floating: boolean;
+interface Message {
   message: string;
-  hideStatusBar: boolean;
+  description?: string;
+  type?: string;
+  backgroundColor?: string;
+  color?: string;
+}
+
+interface MessageComponentProps {
+  position?: Position;
+  floating?: boolean;
+  message: Message;
+  hideStatusBar?: boolean;
   icon: Icon;
   style: StyleProp<ViewStyle>;
   textStyle: StyleProp<TextStyle>;
@@ -47,7 +55,7 @@ interface MessageOptions {
   hideOnPress?: boolean;
   hideStatusBar?: boolean;
   icon?: Icon;
-  message: string;
+  message: Message;
   position?: Position;
   textStyle?: StyleProp<TextStyle>;
   titleStyle?: StyleProp<TextStyle>;


### PR DESCRIPTION
There are some missing type declarations in the `showMessage` method, but are available in the source here:

https://github.com/lucasferreira/react-native-flash-message/blob/master/src/FlashMessage.js#L533

I think there is a bigger problem with how the `message` prop is handled, as it is treated as a string in the TypeScript typings, but it is checked for properties here: https://github.com/lucasferreira/react-native-flash-message/blob/master/src/FlashMessage.js#L503-L507

In the meantime this should act as a workaround for how things should be treated.