### PR TITLE
Get render function from message instance.

### DIFF
--- a/src/FlashMessage.js
+++ b/src/FlashMessage.js
@@ -550,6 +550,7 @@ export default class FlashMessage extends Component {
   }
   render() {
     const { MessageComponent } = this.props;
+    let { renderCustomContent, renderFlashMessageIcon } = this.props;
     const { message, visibleValue } = this.state;
 
     const style = this.prop(message, "style");
@@ -560,8 +561,8 @@ export default class FlashMessage extends Component {
     const icon = parseIcon(this.prop(message, "icon"));
     const hideStatusBar = this.prop(message, "hideStatusBar");
     const transitionConfig = this.prop(message, "transitionConfig");
-    const renderCustomContent = this.prop(message, "renderCustomContent");
-    const renderFlashMessageIcon = this.prop(message, "renderFlashMessageIcon");
+    renderCustomContent = this.prop(message, "renderCustomContent") || renderCustomContent;
+    renderFlashMessageIcon = this.prop(message, "renderFlashMessageIcon") || renderFlashMessageIcon;
     const animated = this.isAnimated(message);
     const animStyle = animated ? transitionConfig(visibleValue, position) : {};
 

--- a/src/FlashMessage.js
+++ b/src/FlashMessage.js
@@ -549,7 +549,7 @@ export default class FlashMessage extends Component {
     this.toggleVisibility(false, animated);
   }
   render() {
-    const { renderFlashMessageIcon, renderCustomContent, MessageComponent } = this.props;
+    const { MessageComponent } = this.props;
     const { message, visibleValue } = this.state;
 
     const style = this.prop(message, "style");
@@ -560,6 +560,8 @@ export default class FlashMessage extends Component {
     const icon = parseIcon(this.prop(message, "icon"));
     const hideStatusBar = this.prop(message, "hideStatusBar");
     const transitionConfig = this.prop(message, "transitionConfig");
+    const renderCustomContent = this.prop(message, "renderCustomContent");
+    const renderFlashMessageIcon = this.prop(message, "renderFlashMessageIcon");
     const animated = this.isAnimated(message);
     const animStyle = animated ? transitionConfig(visibleValue, position) : {};
 


### PR DESCRIPTION
I've modified the `renderCustomContent` and `renderFlashMessageIcon` methods according to issue https://github.com/lucasferreira/react-native-flash-message/issues/51 to make these two render functions able to be passed through the `showMessage` function.