### PR TITLE
Add showMessage & hideMessage typescript declarations into FlashMessage

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -85,6 +85,8 @@ export function positionStyle(style: StyleProp<ViewStyle>, position: Position): 
 export function FlashMessageTransition(animValue: Animated.Value, position: Position): Transition;
 export default class FlashMessage extends React.Component<FlashMessageProps> {
   static setColorTheme(theme: ColorTheme): void;
+  showMessage(options: MessageOptions): void;
+  hideMessage(): void;
 }
 
 export interface ColorTheme {


### PR DESCRIPTION
When referencing local FlashMessage object, the instance functions showMessage & hideMessage are not visible