### PR TITLE
add accessible attribute to false

### DIFF
--- a/src/FlashMessage.js
+++ b/src/FlashMessage.js
@@ -574,7 +574,7 @@ export default class FlashMessage extends Component {
           animStyle,
         ]}>
         {!!message && (
-          <TouchableWithoutFeedback onPress={this.pressMessage} onLongPress={this.longPressMessage}>
+          <TouchableWithoutFeedback onPress={this.pressMessage} onLongPress={this.longPressMessage} accessible={false} >
             <MessageComponent
               position={position}
               floating={floating}


### PR DESCRIPTION
when accessible is set to false ios render button as
```js
<Button>
    <Text>button</Text>
     <Icon>*</Icon>
</Buton>
```
if accessible is set to true (default) it will be rendered like this
```js
<Button>button * </Button>
```
we need to se accessible to false if we want access test inside button using testID for example

