### PR TITLE
Update Message interface to include optional duration

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,6 +25,7 @@ export interface Message {
   type?: string;
   backgroundColor?: string;
   color?: string;
+  duration?: number;
 }
 
 export interface MessageComponentProps {


### PR DESCRIPTION
I was adding a custom message component and was using the duration but its apparently not in the types so I added it here.