### PR TITLE
Correction to work with iPhone 11. 

### DIFF
--- a/src/FlashMessageWrapper.js
+++ b/src/FlashMessageWrapper.js
@@ -67,7 +67,7 @@ const statusBarHeight = (isLandscape = false) => {
 };
 
 const doubleFromPercentString = percent => {
-  if (!percent.includes("%")) {
+  if (!percent || !percent.includes("%")) {
     return 0;
   }
 


### PR DESCRIPTION
I'm testing the component on iPhone 11 and for some reason, the percent variable is not set there. So, as it already is not obligatory, I'm fixing it in case it comes as null.

After this minor fix, it's working like it should.

**Error screenshot:**
<img width="414" alt="Arquivo_001" src="https://user-images.githubusercontent.com/8248858/90435615-9d35dd00-e0a5-11ea-8e42-8e66afbcc115.png">
