### PR TITLE
Add onHide to the MessageOptions interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,9 +5,9 @@ export type Position = "top" | "bottom" | "center" | { top?: number, left?: numb
 export type MessageType = "none" | "default" | "info" | "success" | "danger" | "warning";
 
 export type Icon =
-  | MessageType
+  | MessageType | "auto"
   | {
-      icon: MessageType;
+      icon: MessageType | "auto";
       position: "left" | "right";
     };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -62,6 +62,7 @@ export interface MessageOptions {
   textStyle?: StyleProp<TextStyle>;
   titleStyle?: StyleProp<TextStyle>;
   type?: MessageType;
+  onHide?(): void;
   onPress?(): void;
   onLongPress?(): void;
 }


### PR DESCRIPTION
While working on a TS enabled project, I noticed that the `onHide` prop and `auto` value for the icon prop are missing from the MessageOptions interface.