### PR TITLE
Fix showMessage missing option types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -65,6 +65,11 @@ export interface MessageOptions {
   onHide?(): void;
   onPress?(): void;
   onLongPress?(): void;
+  renderFlashMessageIcon?(
+    icon: Icon,
+    style: StyleProp<ImageStyle>,
+    customProps: Partial<ImageProps>
+  ): React.ReactElement<{}> | null;
 }
 
 export interface FlashMessageProps extends Partial<MessageOptions> {


### PR DESCRIPTION
I added missing prop to `showMessage`. This probably should follow https://github.com/lucasferreira/react-native-flash-message/issues/92.