### PR TITLE
Add React.FC to icon prop types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -61,7 +61,7 @@ export interface MessageOptions {
   hideOnPress?: boolean;
   hideStatusBar?: boolean;
   statusBarHeight?: number;
-  icon?: React.ReactElement | Icon;
+  icon?: React.ReactElement | React.FC | Icon;
   iconProps?: Partial<ImageProps>;
   message: string;
   position?: Position;


### PR DESCRIPTION
Adding React.FC to the icon prop type allows a more flexible method to pass in any component to the icon when using TypeScript.

Example usecase: 

```
showMessage({
    message: 'Warning!',
    type: 'warning',
    icon: () => <MaterialIcon name="warning" color="#ff0000" size={24} />,
})
```

This normally would result in the type error: 

`Type '() => JSX.Element' is not assignable to type 'ReactElement<any, string | JSXElementConstructor<any>> | Icon | undefined'.`

This allows the use of any component for icons which don't require the inferred IconProps to be passed through.
