### PR TITLE
refactor: replace deprecated React.SFC with React.FC

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -90,7 +90,7 @@ export interface FlashMessageProps extends Partial<MessageOptions> {
   testID?: string;
   canRegisterAsDefault?: boolean;
   style?: StyleProp<ViewStyle>;
-  MessageComponent?: React.SFC<MessageComponentProps> | React.ReactElement<MessageComponentProps>;
+  MessageComponent?: React.FC<MessageComponentProps> | React.ReactElement<MessageComponentProps>;
   transitionConfig?(animValue: Animated.Value, position: Position): Transition;
 }
 


### PR DESCRIPTION
The React.SFC type has been deprecated and removed in recent versions. The recommended alternative is React.FunctionComponent or React.FC