### PR TITLE
feat: add accessibilityLabel to the messageOptions interface

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,7 @@ export interface MessageOptions {
   renderBeforeContent?(message: MessageOptions): React.ReactElement<{}> | null;
   renderCustomContent?(message: MessageOptions): React.ReactElement<{}> | null;
   renderAfterContent?(message: MessageOptions): React.ReactElement<{}> | null;
+  accessibilityLabel?: string;
 }
 
 export interface FlashMessageProps extends Partial<MessageOptions> {


### PR DESCRIPTION
This pull request adds an **accessibilityLabel** prop to the **MessageOptions** interface from ShowMessage . The change is minimal but significantly enhances the testability of the component across both Android and iOS platforms when using automated testing tools like Appium.

**Changes Made:**

1. Added **accessibilityLabel** to the **MessageOptions** component in **index.d.ts**.

**Reason for Change:**
While using Appium for end-to-end testing, I encountered difficulties locating the toast element on Android devices, especially on platforms like BrowserStack. The testID prop maps to resource-id on Android, which can cause inconsistencies due to varying package names across environments.

By adding the **accessibilityLabel** prop:

- On Android, it sets the **content-desc** attribute, allowing the element to be located using the **accessibility id** locator strategy in Appium.

- On iOS, it maps to **accessibilityIdentifier**, which is also accessible via the **accessibility id** strategy.

**Issue Observed:**

- On local emulators, tests work correctly because the environment is consistent.
- On BrowserStack's real devices, tests fail to locate the toast element due to variations in device configurations and package names, causing resource-id based locators to fail.
